### PR TITLE
Memory exploding problem when training 

### DIFF
--- a/STAGATE_pyG/Train_STAGATE.py
+++ b/STAGATE_pyG/Train_STAGATE.py
@@ -75,13 +75,11 @@ def train_STAGATE(adata, hidden_dims=[512, 30], n_epochs=1000, lr=0.001, key_add
 
     optimizer = torch.optim.Adam(model.parameters(), lr=lr, weight_decay=weight_decay)
 
-    loss_list = []
     for epoch in tqdm(range(1, n_epochs+1)):
         model.train()
         optimizer.zero_grad()
         z, out = model(data.x, data.edge_index)
         loss = F.mse_loss(data.x, out) #F.nll_loss(out[data.train_mask], data.y[data.train_mask])
-        loss_list.append(loss)
         loss.backward()
         torch.nn.utils.clip_grad_norm_(model.parameters(), gradient_clipping)
         optimizer.step()


### PR DESCRIPTION
There is a memory exploding problem when running `train_STAGATE` because the code stores losses.
I resolved this problem by removing `loss_list` which is not used in the other part of the training code.
